### PR TITLE
Fix duplicate exception handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,10 +64,8 @@ try:
     st.pyplot(fig)
 
 except Exception as e:
-    st.warning("Something went wrong. Double-check tickers and date range.")
-    st.exception(e)
-
-except Exception as e:
-    st.warning("Please enter valid tickers and make sure data exists for the selected range.")
+    st.warning(
+        "Please enter valid tickers and make sure data exists for the selected range."
+    )
     st.exception(e)
 


### PR DESCRIPTION
## Summary
- remove redundant `except` block in the Streamlit app
- show a single warning message when any exception occurs

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685c6eaa99b88328a48957854b650c60