### PR TITLE
Add portfolio tracker to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# stock-dashboard
+# Stock Dashboard
+
+This Streamlit app analyzes a stock's beta and volatility versus a benchmark. It also contains a **Portfolio Tracker** for monitoring an entire portfolio.
+
+The tracker verifies each ticker and automatically fetches the price on the purchase date. Enter the number of shares and choose whether to track the holding in its native currency or convert values to USD. Holdings can be edited or removed and a chart displays the portfolio’s value over time.

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 import altair as alt
 import datetime as dt
+from typing import List, Dict
 
 st.set_page_config(page_title="Stock Beta & Vol Analyzer", layout="centered")
 
@@ -182,6 +183,192 @@ try:
 """,
         unsafe_allow_html=True,
     )
+
+    # ── Portfolio Tracker ─────────────────────────────────────────────────
+    st.subheader("📒 Portfolio Tracker")
+
+    if "portfolio" not in st.session_state:
+        st.session_state["portfolio"] = []
+
+    def validate_symbol(symbol: str):
+        """Check if ticker exists and return metadata."""
+        try:
+            info = yf.Ticker(symbol).info
+            name = info.get("shortName") or info.get("longName")
+            if name:
+                return {"currency": info.get("currency", "USD"), "name": name}
+        except Exception:
+            pass
+        return None
+
+    def fx_to_usd(value: float, currency: str) -> float:
+        """Convert value to USD if a FX rate is available."""
+        if currency == "USD":
+            return value
+        try:
+            pair = f"{currency}USD=X"
+            rate = (
+                yf.download(pair, period="1d", auto_adjust=True)["Close"].iloc[-1]
+            )
+            return value * rate
+        except Exception:
+            return value
+
+    def price_on_date(symbol: str, date: dt.date) -> float:
+        """Get the first available closing price on or after the date."""
+        try:
+            data = yf.download(
+                symbol,
+                start=date,
+                end=date + dt.timedelta(days=5),
+                auto_adjust=True,
+            )["Close"]
+            if not data.empty:
+                return data.iloc[0]
+        except Exception:
+            pass
+        return float("nan")
+
+    with st.form("add_asset"):
+        a_cols = st.columns(4)
+        sym = a_cols[0].text_input("Symbol")
+        date_bought = a_cols[1].date_input("Buy Date", today)
+        shares = a_cols[2].number_input("Shares", min_value=0.0, step=0.01)
+        track_usd = a_cols[3].checkbox("Track in USD", value=True)
+        submitted = st.form_submit_button("Add")
+
+        if submitted and sym:
+            info = validate_symbol(sym)
+            if not info:
+                st.error("Invalid ticker symbol")
+            else:
+                px = price_on_date(sym, date_bought)
+                if np.isnan(px):
+                    st.error("Price not available for that date")
+                else:
+                    invested = shares * px
+                    asset_currency = info["currency"]
+                    currency = "USD" if track_usd else asset_currency
+                    if track_usd:
+                        invested = fx_to_usd(invested, asset_currency)
+                    st.session_state["portfolio"].append(
+                        {
+                            "symbol": sym.upper(),
+                            "date": date_bought,
+                            "shares": shares,
+                            "invested": invested,
+                            "asset_currency": asset_currency,
+                            "currency": currency,
+                        }
+                    )
+
+    if st.session_state["portfolio"]:
+        pf_df = pd.DataFrame(st.session_state["portfolio"])
+
+        try:
+            latest = (
+                yf.download(
+                    list(pf_df["symbol"].unique()),
+                    period="1d",
+                    auto_adjust=True,
+                )["Close"].iloc[-1]
+            )
+        except Exception:
+            latest = pd.Series(dtype=float)
+
+        pf_df["Current"] = pf_df["symbol"].map(latest)
+
+        def cur_price(row: pd.Series) -> float:
+            price = row["Current"]
+            if row["currency"] == "USD":
+                price = fx_to_usd(price, row["asset_currency"])
+            return price
+
+        pf_df["Current"] = pf_df.apply(cur_price, axis=1)
+        pf_df["Current Value"] = pf_df["shares"] * pf_df["Current"]
+        pf_df["P/L"] = pf_df["Current Value"] - pf_df["invested"]
+
+        st.dataframe(
+            pf_df[["symbol", "date", "shares", "currency", "invested", "Current Value", "P/L"]],
+            use_container_width=True,
+        )
+
+        # ----- Edit/Delete Buttons -----
+        for i in pf_df.index:
+            e_col, d_col = st.columns(2)
+            if e_col.button("Edit", key=f"edit_{i}"):
+                st.session_state["edit_idx"] = int(i)
+            if d_col.button("Delete", key=f"del_{i}"):
+                st.session_state["portfolio"].pop(int(i))
+                st.experimental_rerun()
+
+        if "edit_idx" in st.session_state:
+            idx = st.session_state.pop("edit_idx")
+            asset = st.session_state["portfolio"][idx]
+            with st.form("edit_asset"):
+                e_cols = st.columns(4)
+                sym_e = e_cols[0].text_input("Symbol", asset["symbol"])
+                date_e = e_cols[1].date_input("Buy Date", asset["date"])
+                shares_e = e_cols[2].number_input("Shares", value=asset["shares"], min_value=0.0, step=0.01)
+                usd_e = e_cols[3].checkbox("Track in USD", value=asset["currency"] == "USD")
+                save = st.form_submit_button("Save")
+
+                if save:
+                    info = validate_symbol(sym_e)
+                    if info:
+                        px = price_on_date(sym_e, date_e)
+                        if not np.isnan(px):
+                            invested = shares_e * px
+                            asset_currency = info["currency"]
+                            currency = "USD" if usd_e else asset_currency
+                            if usd_e:
+                                invested = fx_to_usd(invested, asset_currency)
+                            st.session_state["portfolio"][idx] = {
+                                "symbol": sym_e.upper(),
+                                "date": date_e,
+                                "shares": shares_e,
+                                "invested": invested,
+                                "asset_currency": asset_currency,
+                                "currency": currency,
+                            }
+                            st.experimental_rerun()
+
+        # ----- Return Chart -----
+        try:
+            price_series = []
+            for asset in st.session_state["portfolio"]:
+                hist = yf.download(
+                    asset["symbol"],
+                    start=asset["date"],
+                    end=today + dt.timedelta(days=1),
+                    auto_adjust=True,
+                )["Close"]
+                if asset["currency"] == "USD":
+                    fx_hist = yf.download(
+                        f"{asset['asset_currency']}USD=X",
+                        start=asset["date"],
+                        end=today + dt.timedelta(days=1),
+                        auto_adjust=True,
+                    )["Close"]
+                    hist = hist.mul(fx_hist, fill_value=np.nan)
+                price_series.append(hist * asset["shares"])
+
+            if price_series:
+                portfolio_val = pd.concat(price_series, axis=1).fillna(method="ffill").sum(axis=1)
+                chart_df = portfolio_val.reset_index().rename(columns={0: "Value", "index": "Date"})
+                chart = (
+                    alt.Chart(chart_df)
+                    .mark_line()
+                    .encode(
+                        x="Date:T",
+                        y=alt.Y("Value:Q", title="Portfolio Value"),
+                        tooltip=["Date:T", alt.Tooltip("Value:Q", format=".2f")],
+                    )
+                    .interactive()
+                )
+                st.altair_chart(chart, use_container_width=True)
+        except Exception:
+            pass
 
 except Exception as e:
     st.error(f"Error: {e}")


### PR DESCRIPTION
## Summary
- add a portfolio tracker section to the Streamlit app
- document the new feature in README

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685e257628dc8328b121cb8818e4dc89