### PR TITLE
Add helper tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+      - name: Run tests
+        run: pytest

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import altair as alt
 import datetime as dt
 from typing import List, Dict
 
+from helpers import fx_to_usd, price_on_date
 st.set_page_config(page_title="Stock Beta & Vol Analyzer", layout="centered")
 
 # ── Title ──────────────────────────────────────────────────────────────────
@@ -193,31 +194,6 @@ try:
             pass
         return None
 
-    def fx_to_usd(value: float, currency: str) -> float:
-        """Convert value to USD if a FX rate is available."""
-        if currency == "USD":
-            return value
-        try:
-            pair = f"{currency}USD=X"
-            rate = yf.download(pair, period="1d", auto_adjust=True)["Close"].iloc[-1]
-            return value * rate
-        except Exception:
-            return value
-
-    def price_on_date(symbol: str, date: dt.date) -> float:
-        """Get the first available closing price on or after the date."""
-        try:
-            data = yf.download(
-                symbol,
-                start=date,
-                end=date + dt.timedelta(days=5),
-                auto_adjust=True,
-            )["Close"]
-            if not data.empty:
-                return data.iloc[0]
-        except Exception:
-            pass
-        return float("nan")
 
     with st.form("add_asset"):
         a_cols = st.columns(4)

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,31 @@
+import datetime as dt
+
+import yfinance as yf
+
+
+def fx_to_usd(value: float, currency: str) -> float:
+    """Convert value to USD if a FX rate is available."""
+    if currency == "USD":
+        return value
+    try:
+        pair = f"{currency}USD=X"
+        rate = yf.download(pair, period="1d", auto_adjust=True)["Close"].iloc[-1]
+        return value * rate
+    except Exception:
+        return value
+
+
+def price_on_date(symbol: str, date: dt.date) -> float:
+    """Get the first available closing price on or after the date."""
+    try:
+        data = yf.download(
+            symbol,
+            start=date,
+            end=date + dt.timedelta(days=5),
+            auto_adjust=True,
+        )["Close"]
+        if not data.empty:
+            return data.iloc[0]
+    except Exception:
+        pass
+    return float("nan")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+import types
+import os
+import datetime as dt
+import math
+
+class FakeSeries:
+    def __init__(self, values):
+        self._values = list(values)
+
+    @property
+    def empty(self):
+        return len(self._values) == 0
+
+    class ILoc:
+        def __init__(self, values):
+            self.values = values
+
+        def __getitem__(self, idx):
+            return self.values[idx]
+
+    @property
+    def iloc(self):
+        return FakeSeries.ILoc(self._values)
+
+class FakeData(dict):
+    def __init__(self, values):
+        super().__init__()
+        self["Close"] = FakeSeries(values)
+
+def load_helpers(fake_download):
+    sys.modules['yfinance'] = types.SimpleNamespace(download=fake_download)
+    if 'helpers' in sys.modules:
+        del sys.modules['helpers']
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    return importlib.import_module('helpers')
+
+def test_fx_to_usd_no_conversion():
+    helpers = load_helpers(lambda *a, **k: FakeData([1]))
+    assert helpers.fx_to_usd(10, 'USD') == 10
+
+def test_fx_to_usd_with_rate():
+    helpers = load_helpers(lambda *a, **k: FakeData([1.2]))
+    assert helpers.fx_to_usd(10, 'EUR') == 12
+
+def test_price_on_date_value():
+    helpers = load_helpers(lambda *a, **k: FakeData([100, 101]))
+    date = dt.date(2023, 1, 1)
+    assert helpers.price_on_date('AAPL', date) == 100
+
+def test_price_on_date_no_data():
+    helpers = load_helpers(lambda *a, **k: FakeData([]))
+    result = helpers.price_on_date('AAPL', dt.date(2023, 1, 1))
+    assert math.isnan(result)


### PR DESCRIPTION
## Summary
- extract `fx_to_usd` and `price_on_date` into `helpers.py`
- add pytest tests for these helper functions
- run the tests with GitHub Actions on each push

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686079e34f588328858a041c354cda37