### PR TITLE
Fix price_on_date float casting

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -25,7 +25,10 @@ def price_on_date(symbol: str, date: dt.date) -> float:
             auto_adjust=True,
         )["Close"]
         if not data.empty:
-            return data.iloc[0]
+            value = data.iloc[0]
+            if hasattr(value, "item"):
+                value = value.item()
+            return float(value)
     except Exception:
         pass
     return float("nan")


### PR DESCRIPTION
## Summary
- ensure `price_on_date` returns a Python float

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bd71fe1c83288ed0aa3a939c0d9a