### PR TITLE
Implement multi-stock analytics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ streamlit
 yfinance
 pandas
 numpy
+statsmodels
 matplotlib
+altair
 requests


### PR DESCRIPTION
## Summary
- add multi-stock analysis section using correlation heatmaps, betas, rolling correlations, and trend regressions
- cache multi-ticker price downloads
- include required libs in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c24e74ac83288a5298e5a8268f17