### PR TITLE
Fix merge conflicts and refine correlation plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ The tracker verifies each ticker and automatically fetches the price on the purc
 ## Multi-Stock Analysis
 
 Select multiple tickers and a benchmark in the sidebar to compare their daily returns. The dashboard displays a correlation heatmap, betas and R² values, rolling correlations, and simple trend regressions so you can explore how groups of assets move together.
+
+The app uses SciPy's `linregress` for regression calculations, so the Statsmodels dependency is no longer required.

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import altair as alt
 import datetime as dt
 from typing import List, Dict
 import matplotlib.pyplot as plt
-import statsmodels.api as sm
+from scipy.stats import linregress
 
 from helpers import fx_to_usd, price_on_date, search_tickers
 st.set_page_config(page_title="Stock Beta & Vol Analyzer", layout="centered")
@@ -48,9 +48,10 @@ def fetch_px(tick, start, end):
 
 @st.cache_data
 def fetch_px_multi(ticks: List[str], start, end):
-    data = yf.download(ticks, start=start, end=end)["Adj Close"]
-    data.index = data.index.date
-    return data
+    data = yf.download(ticks, start=start, end=end, auto_adjust=True)
+    close = data["Close"] if isinstance(data, pd.DataFrame) else data
+    close.index = close.index.date
+    return close
 
 try:
     px_stock = fetch_px(ticker, start, end)
@@ -230,10 +231,10 @@ try:
         r2s = {}
         for t in tickers_ms:
             y = rets_ms[t]
-            X = sm.add_constant(rets_ms[bench_ms])
-            model = sm.OLS(y, X).fit()
-            betas[t] = model.params[bench_ms]
-            r2s[t] = model.rsquared
+            x = rets_ms[bench_ms]
+            res = linregress(x, y)
+            betas[t] = res.slope
+            r2s[t] = res.rvalue ** 2
 
         beta_df = pd.DataFrame({"Beta": betas, "R²": r2s}).T.sort_index()
         st.subheader("Market Sensitivity")
@@ -244,14 +245,27 @@ try:
             rets_ms[tickers_ms].rolling(window).corr(rets_ms[bench_ms]).dropna()
         )
         st.subheader(f"Rolling {window}-day Correlation vs {bench_ms}")
-        for t in tickers_ms:
-            st.line_chart(rolling_corr.xs(t, level=1))
+
+        if isinstance(rolling_corr, pd.Series):
+            # Only one ticker selected; Series indexed by date
+            st.line_chart(rolling_corr)
+
+        elif isinstance(rolling_corr.index, pd.MultiIndex):
+            # MultiIndex: first level is date, second level is ticker
+            for t in tickers_ms:
+                st.line_chart(rolling_corr.xs(t, level=1))
+
+        else:
+            # DataFrame with date index and tickers as columns
+            for t in tickers_ms:
+                st.line_chart(rolling_corr[t])
 
         cum = (1 + rets_ms).cumprod() - 1
         for t in tickers_ms:
             y = cum[t].values
-            X = sm.add_constant(np.arange(len(y)))
-            slope, intercept = sm.OLS(y, X).fit().params
+            x = np.arange(len(y))
+            res = linregress(x, y)
+            slope, intercept = res.slope, res.intercept
             st.write(
                 f"**{t}** trend ≈ {slope*100:.2f}% / day  (intercept {intercept:.2f})"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ numpy
 pandas
 requests
 scipy
-statsmodels
 streamlit
 yfinance


### PR DESCRIPTION
## Summary
- replace Statsmodels with SciPy's `linregress`
- load multi-stock data using auto-adjusted Close prices
- handle single ticker rolling correlations with an `if`/`elif` chain
- document the switch to `linregress`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f24c2d408328be09305c7988d51f